### PR TITLE
allow passing in severity option

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -2,4 +2,5 @@ export default {
   ignoreVariables: true,
   ignoreFunctions: true,
   ignoreKeywords: null,
+  severity: 'error',
 }

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -18,6 +18,7 @@ function validProperties(actual) {
  * @param {Object} actual - The actual config to validate.
  * @param {boolean} [actual.ignoreVariables=true] - Whether or not to lint variables.
  * @param {boolean} [actual.ignoreFunctions=true] - Whether or not to lint functions.
+ * @param {string} [actual.severity='error'] - What the severity level is for this rule.
  * @param {string|Array|Object} [actual.ignoreKeywords=null] - A keywords config.
  *
  * @returns {boolean}
@@ -35,6 +36,10 @@ function validOptions(actual) {
   if ('ignoreFunctions' in actual &&
     typeof actual.ignoreFunctions !== 'boolean' &&
     actual.ignoreFunctions !== null) return false
+
+  if ('severity' in actual &&
+    typeof actual.severity !== 'string' &&
+    actual.severity !== null) return false
 
   if ('ignoreKeywords' in actual &&
     !validProperties(actual.ignoreKeywords) &&


### PR DESCRIPTION
This allows passing in a severity option to allow setting all rule violations as warnings as per stylelint configuration at https://stylelint.io/user-guide/configuration/#severities-error--warning