### PR TITLE
Chore/add dot env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.env
 /node_modules/
 /dist/
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 [![Build Status](https://travis-ci.org/AndyOGo/stylelint-declaration-strict-value.svg?branch=master)](https://travis-ci.org/AndyOGo/stylelint-declaration-strict-value)
 
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+
 A [stylelint](https://github.com/stylelint/stylelint) plugin that enforces either variables (`$sass`, `namespace.$sass`, `@less`, `var(--cssnext)`), functions or custom CSS keywords (`inherit`, `none`, etc.) for property's values.
 
 # Installation

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-preset-es2015": "^6.24.1",
     "doctoc": "^1.4.0",
     "documentation": "^12.3.0",
+    "dotenv-cli": "^3.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "unpkg": "dist/index.umd.js",
   "scripts": {
     "build": "microbundle",
-    "release": "semantic-release",
+    "release": "dotenv-cli semantic-release",
     "prerelease": "npm run build",
     "test": "node -r esm test",
     "eslint": "eslint 'src/**/*.js' 'test/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "microbundle",
     "release": "dotenv-cli semantic-release",
-    "prerelease": "npm run build",
+    "prepack": "npm run build",
     "test": "node -r esm test",
     "eslint": "eslint 'src/**/*.js' 'test/**/*.js'",
     "docs": "documentation build src/index.js -f md -o API.md",


### PR DESCRIPTION
Add `.env` file for `GH_TOKEN` needed for `semantic-release` authentication.
https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication