### PR TITLE
Add failing test for multiple values

### DIFF
--- a/test/shorthand.js
+++ b/test/shorthand.js
@@ -349,3 +349,23 @@ testRule(rule, {
     },
   ],
 });
+
+// testRule(rule, {
+//   ruleName,
+//   skipBasicChecks: true,
+
+//   config: [
+//     ['box-shadow'],
+//     {
+//       ignoreValues: {
+//         'box-shadow': ['/\\d{1}px/'],
+//       },
+//     },
+//   ],
+
+//   accept: [
+//     {
+//       code: '.foo { box-shadow: 0px 0px 0px 1px var(--bar), 0px 0px 0px 2px var(--baz); }',
+//     },
+//   ],
+// });


### PR DESCRIPTION
The goal of the config in this test is to allow developers to use any pixel values for a box shadow, but enforce a variable/function for the colour part.

stylelint-declaration-strict-value supports this already.

But, not when box-shadow has multiple values separated by a comma.

Thoughts?


_Note_: I had to comment out the failing test, because I wasn't able to push it up due to pre commit hooks
_Edit_: Also it could probably be moved to a more appropriate file