### PR TITLE
Update stylelint peer dependency to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/AndyOGo/stylelint-declaration-strict-value#readme",
   "peerDependencies": {
-    "stylelint": ">=7 <=13"
+    "stylelint": ">=7 <=14"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
Stylelint is now on v14 and I would like to use stylelint-declaration-strict-value with the latest and greatest.

Unfortunately I was not able to fully test this change. When I check out the code and run `npm i --force && npm run build && npm test` I get:

```
> stylelint-declaration-strict-value@1.7.12 test
> node --require babel-register-ts test

node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '/Users/isaac/Code/scratch/huskytest/node_modules/stylelint-declaration-strict-value/test'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

And I tried importing my fork into another project, but it has sent me down a deep rabbit hole with mismatched husky dependencies. Edit: I was eventually able to get it running. I can confirm that it ran successfully, but I have not tried to check that all the behavior is the same.

So, consider this PR to be speculative until someone is able to run this repo's tests. There are some [breaking changes](https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-14.md) in v14, some of which might be relevant here, but I wasn't able to dig further into it.