### PR TITLE
Update stylelint, its deps and peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/AndyOGo/stylelint-declaration-strict-value#readme",
   "peerDependencies": {
-    "stylelint": ">=7 <=13"
+    "stylelint": "^14"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",
@@ -63,7 +63,7 @@
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
-    "@types/stylelint": "^9.10.1",
+    "@types/stylelint": "^13.13.3",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "babel-register-ts": "^7.0.0",
@@ -83,10 +83,10 @@
     "pinst": "^2.1.6",
     "prettier": "^2.2.1",
     "semantic-release": "^17.3.0",
-    "stylelint": "^13.8.0",
+    "stylelint": "^14.0.1",
     "stylelint-test-rule-tape": "^0.2.0",
-    "typedoc": "^0.20.10",
-    "typedoc-plugin-markdown": "^3.2.1",
+    "typedoc": "^0.22.7",
+    "typedoc-plugin-markdown": "^3.11.3",
     "typescript": "^4.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
stylelint-declaration-strict-value currently doesn't work for stylelint over 13. This PR fixes this problem:

```shelll
$ npm install stylelint-declaration-strict-value --save-dev
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: testproject@1.0.0
npm ERR! Found: stylelint@14.0.1
npm ERR! node_modules/stylelint
npm ERR!   dev stylelint@"^14.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer stylelint@">=7 <=13" from stylelint-declaration-strict-value@1.7.12
npm ERR! node_modules/stylelint-declaration-strict-value
npm ERR!   dev stylelint-declaration-strict-value@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/rolle/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rolle/.npm/_logs/2021-11-04T09_12_15_269Z-debug.log
```