### PR TITLE
autofix now can throw error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,6 +1379,10 @@ function autoFixFunc(node, validation, root, config) {
       case 'red':
         // auto-fix by PostCSS AST tranformation
         node.value = '$color-red'
+
+      // optional, you can throw your own error message if the value is not stated or handled, ex: color: blue
+      throw `Property ${prop} with value ${value} can't be autofix`
+      // 
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,24 +416,37 @@ const ruleFunction: StylelintPlugin<PrimaryOptions, SecondaryOptions> =
 
           // support auto fixing
           if (context.fix && !disableFix && autoFixFuncNormalized) {
-            const fixedValue = autoFixFuncNormalized(
-              node,
-              {
-                validVar,
-                validFunc,
-                validKeyword,
-                validValue,
-                longhandProp,
-                longhandValue,
-              },
-              root,
-              config
-            );
+            try {
+              const fixedValue = autoFixFuncNormalized(
+                node,
+                {
+                  validVar,
+                  validFunc,
+                  validKeyword,
+                  validValue,
+                  longhandProp,
+                  longhandValue,
+                },
+                root,
+                config
+              );
 
-            // apply fixed value if returned
-            if (fixedValue) {
-              // eslint-disable-next-line no-param-reassign
-              node.value = fixedValue;
+              // apply fixed value if returned
+              if (fixedValue) {
+                // eslint-disable-next-line no-param-reassign
+                node.value = fixedValue;
+              }
+            } catch (err: unknown) {
+              if (typeof err === 'string') {
+                utils.report({
+                  ruleName,
+                  result,
+                  node,
+                  line: node.source!.start.line,
+                  // column: start!.column + nodeProp.length + raws.between!.length,
+                  message: err,
+                });
+              }
             }
           } else {
             const { raws } = node;

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,16 +437,18 @@ const ruleFunction: StylelintPlugin<PrimaryOptions, SecondaryOptions> =
                 node.value = fixedValue;
               }
             } catch (err: unknown) {
-              if (typeof err === 'string') {
+              if (err instanceof Error) {
                 utils.report({
                   ruleName,
                   result,
                   node,
-                  line: node.source!.start.line,
-                  // column: start!.column + nodeProp.length + raws.between!.length,
-                  message: err,
+                  line: node.source!.start?.line,
+                  message: err.toString(),
                 });
+                return
               }
+  
+              throw err
             }
           } else {
             const { raws } = node;

--- a/test/auto-fix-func.js
+++ b/test/auto-fix-func.js
@@ -60,7 +60,7 @@ testRule(
     reject: [
       {
         code: '.foo { font-size: 16px; }',
-        message: `Property font-size with value 16px can't be autofix (${ruleName})`,
+        message: `Property font-size with value 16px can't be autofix`,
         line: 1,
         column: 8
       }

--- a/test/auto-fix-func.js
+++ b/test/auto-fix-func.js
@@ -46,7 +46,7 @@ testRule(
     skipBasicChecks: true,
 
     config: [
-      'color',
+      ['color', 'font-size'],
       {
         autoFixFunc,
       },
@@ -56,6 +56,15 @@ testRule(
       { code: '.foo { color: #fff; }' },
       { code: '.foo { color: red; }' },
     ],
+
+    reject: [
+      {
+        code: '.foo { font-size: 16px; }',
+        message: `Property font-size with value 16px can't be autofix (${ruleName})`,
+        line: 1,
+        column: 8
+      }
+    ]
   }
 );
 

--- a/test/helpers/auto-fix-func.js
+++ b/test/helpers/auto-fix-func.js
@@ -16,7 +16,7 @@ function autoFixFunc(node, validation, root, config) {
         return;
     }
   }
-  throw `Property ${prop} with value ${value} can't be autofix (scale-unlimited/declaration-strict-value)`
+  throw `Property ${prop} with value ${value} can't be autofix`
 }
 
 module.exports = autoFixFunc;

--- a/test/helpers/auto-fix-func.js
+++ b/test/helpers/auto-fix-func.js
@@ -13,8 +13,10 @@ function autoFixFunc(node, validation, root, config) {
         // auto-fix by PostCSS AST tranformation
         // eslint-disable-next-line no-param-reassign
         node.value = '$color-red';
+        return;
     }
   }
+  throw `Property ${prop} with value ${value} can't be autofix (scale-unlimited/declaration-strict-value)`
 }
 
 module.exports = autoFixFunc;


### PR DESCRIPTION
This PR allows autoFixFunc to throw error (ex: when switch statement is not found or matched) as requested on this issue #251 

Currently if autoFixFunc is supplied, it can't throw error if the prop is not being handled, this way the devs has options to throw error if it happens