### PR TITLE
feat: support stylelint v16

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,8 +1,11 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { getTestRule } = require('jest-preset-stylelint');
-const { lint } = require('stylelint');
+import { getTestRule } from 'jest-preset-stylelint';
+import { lint } from 'stylelint';
+// eslint-disable-next-line import/extensions
+import declarationStrictValuePlugin from './src/index.ts';
 
-global.testRule = getTestRule({ plugins: ['./src/index.ts'] });
+const plugins = [declarationStrictValuePlugin];
+
+global.testRule = getTestRule({ plugins });
 
 global.testCustomAutoFixMessage = testCustomAutoFixMessage;
 
@@ -19,11 +22,12 @@ function testCustomAutoFixMessage({ ruleName, config, reject, fix }) {
             fix,
             code,
             config: {
-              plugins: ['./src/index.ts'],
+              plugins,
               rules: {
                 [ruleName]: config,
               },
             },
+            quietDeprecationWarnings: true,
           });
 
           return { message, warnings };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   '(src|test)/**/*.[tj]s': (filenames) => [
     `eslint --fix ${filenames.join(' ')}`,
-    'jest',
+    'cross-env NODE_OPTIONS="--experimental-vm-modules --no-warnings" jest',
   ],
   '(README).md': ["doctoc --title '**Table of Contents**'"],
 };

--- a/package.json
+++ b/package.json
@@ -3,14 +3,22 @@
   "version": "1.9.2",
   "description": "Specify properties for which a variable, function, keyword or value must be used",
   "source": "src/index.ts",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.js",
+    "default": "./dist/index.mjs.js"
+  },
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=18.12.0"
+  },
   "scripts": {
     "build": "microbundle --tsconfig tsconfig.build.json --compress",
     "release": "dotenv semantic-release",
-    "test": "jest",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest",
     "coverage": "jest --config='./jest.coverage.config.js'",
     "postcoverage": "dotenv codecov",
     "eslint": "eslint 'src/**/*.[tj]s' 'test/**/*.[tj]s'",
@@ -45,7 +53,7 @@
   },
   "homepage": "https://github.com/AndyOGo/stylelint-declaration-strict-value#readme",
   "peerDependencies": {
-    "stylelint": ">=7 <=15"
+    "stylelint": ">=7 <=16"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",
@@ -68,6 +76,7 @@
     "babel-jest": "^29.4.2",
     "babel-register-ts": "^7.0.0",
     "codecov": "^3.8.1",
+    "cross-env": "^7.0.3",
     "doctoc": "^2.0.0",
     "dotenv-cli": "^4.0.0",
     "eslint": "^7.14.0",
@@ -78,14 +87,14 @@
     "eslint-plugin-tsdoc": "^0.2.7",
     "husky": "^6.0.0",
     "jest": "^29.4.2",
-    "jest-preset-stylelint": "^6.1.0",
+    "jest-preset-stylelint": "^7.0.0",
     "lint-staged": "^10.5.2",
-    "microbundle": "^0.12.0",
+    "microbundle": "^0.15.1",
     "nyc": "^15.1.0",
     "pinst": "^2.1.6",
     "prettier": "^2.2.1",
     "semantic-release": "^17.3.0",
-    "stylelint": "^15.1.0",
+    "stylelint": "^16.1.0",
     "typedoc": "^0.22.7",
     "typedoc-plugin-markdown": "^3.2.1",
     "typescript": "^4.1.2"

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,4 +1,4 @@
-import type { Node, Root } from 'stylelint/node_modules/postcss';
+import type { Node, Root } from 'postcss';
 
 /**
  * Rule Name.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Declaration, Root, AtRule } from 'stylelint/node_modules/postcss';
+import type { Declaration, Root, AtRule } from 'postcss';
 import stylelint, { PostcssResult, Rule } from 'stylelint';
 import shortCSS from 'shortcss';
 import list from 'shortcss/lib/list';


### PR DESCRIPTION
fixes #327 

Follows https://stylelint.io/migration-guide/to-16/

**Note 1:** ESM requires experimental node features

> The preset needs the `--experimental-vm-modules` Node.js flag to support ESM
> If you get an error (e.g. a segmentation fault while running the preset on Node.js 18),
https://stylelint.io/migration-guide/to-16/#jest-preset-stylelint

**Node 2:** `stylelint.lint()` CommonJS Node API is deprecated and will be removed.

> Using the CommonJS Node.js API will trigger a deprecation warning. If you're not quite ready to migrate to ESM yet, you can use the [`quietDeprecationWarnings`](https://stylelint.io/user-guide/options#quietdeprecationwarnings) option to hide the warning.
https://stylelint.io/migration-guide/to-16/#stylelintlint