### PR TITLE
fix: error [ERR_MODULE_NOT_FOUND]: Cannot find module 'shortcss/lib/l…

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "babel-register-ts": "^7.0.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",
+    "css-values": "^0.1.0",
     "doctoc": "^2.0.0",
     "dotenv-cli": "^4.0.0",
     "eslint": "^7.14.0",
@@ -94,13 +95,10 @@
     "pinst": "^2.1.6",
     "prettier": "^2.2.1",
     "semantic-release": "^17.3.0",
+    "shortcss": "^0.1.3",
     "stylelint": "^16.1.0",
     "typedoc": "^0.22.7",
     "typedoc-plugin-markdown": "^3.2.1",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "css-values": "^0.1.0",
-    "shortcss": "^0.1.3"
   }
 }


### PR DESCRIPTION
fixes #327 

Moved `shortcss` and `css-values` to `devDependencies` to include them within the bundle (microbundle inject `devDependencies`)
https://github.com/developit/microbundle/issues/633#issuecomment-1207138431

```sh
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'shortcss/lib/list' imported from stylelint-declaration-strict-value/dist/index.modern.mjs
Did you mean to import shortcss/lib/list.js?
    at finalizeResolution (node:internal/modules/esm/resolve:255:11)
    at moduleResolve (node:internal/modules/esm/resolve:908:10)
    at defaultResolve (node:internal/modules/esm/resolve:1121:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36)
 ```