### PR TITLE
fix: unknown rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import type { Declaration, Root, AtRule } from 'postcss';
 import stylelint, { PostcssResult, Rule } from 'stylelint';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import shortCSS from 'shortcss';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import list from 'shortcss/lib/list';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import cssValues from 'css-values';
 
 import {
@@ -496,4 +499,4 @@ const declarationStrictValuePlugin = stylelint.createPlugin(
 );
 
 export default declarationStrictValuePlugin;
-export { ruleName, messages };
+export { ruleName, messages, ruleFunction as rule };


### PR DESCRIPTION
improves #327 

Somehow the default export is duplicated  😕 

```sh
[Module: null prototype] {
  default: {
    default: {
      ruleName: 'scale-unlimited/declaration-strict-value',
      rule: [Function]
    },
    messages: {
      expected: [Function (anonymous)],
      customExpected: [Function (anonymous)],
      failedToFix: [Function (anonymous)]
    },
    ruleName: 'scale-unlimited/declaration-strict-value'
  },
  messages: {
    expected: [Function (anonymous)],
    customExpected: [Function (anonymous)],
    failedToFix: [Function (anonymous)]
  },
  ruleName: 'scale-unlimited/declaration-strict-value'
}
```