### PR TITLE
chore(deps-dev): bump typedoc from 0.22.7 to 0.26.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "semantic-release": "^17.3.0",
     "shortcss": "^0.1.3",
     "stylelint": "^16.1.0",
-    "typedoc": "^0.22.7",
+    "typedoc": "^0.26.5",
     "typedoc-plugin-markdown": "^3.2.1",
     "typescript": "^4.1.2"
   }


### PR DESCRIPTION
This PR fixes the dependency installation error below:

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: stylelint-declaration-strict-value@1.10.4
npm error Found: typedoc@0.22.18
npm error node_modules/typedoc
npm error   dev typedoc@"^0.22.7" from the root project
npm error
npm error Could not resolve dependency:
npm error peer typedoc@">=0.24.0" from typedoc-plugin-markdown@3.17.1
npm error node_modules/typedoc-plugin-markdown
npm error   dev typedoc-plugin-markdown@"^3.2.1" from the root project
```

Ref https://github.com/stylelint/stylelint-ecosystem-tester/actions/runs/10136076046/job/28024366171#step:8:1
