### PR TITLE
chore: quiet context.fix API deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-config-airbnb-typescript": "^12.0.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-jest": "^24.7.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-tsdoc": "^0.2.7",
         "husky": "^6.0.0",
@@ -7241,6 +7242,28 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
+      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": ">= 4",
+        "eslint": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.4.1",
@@ -26680,6 +26703,15 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
+      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.0.1"
       }
     },
     "eslint-plugin-jsx-a11y": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-config-airbnb-typescript": "^12.0.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.7.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-tsdoc": "^0.2.7",
     "husky": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ import defaults, {
   IgnoreValue,
   RegExpString,
 } from './defaults';
+import unsafeQuietStylelintDeprecationWarning from './unsafe-quiet-stylelint-deprecation-warning';
+
+unsafeQuietStylelintDeprecationWarning();
 
 const { utils } = stylelint;
 const meta: RuleMeta = {

--- a/src/unsafe-quiet-stylelint-deprecation-warning.ts
+++ b/src/unsafe-quiet-stylelint-deprecation-warning.ts
@@ -1,0 +1,34 @@
+import process from 'node:process';
+import { ruleName } from './defaults';
+
+// internal warning code
+// @see: https://github.com/stylelint/stylelint/blob/3a903800248fcccd4968e8e0dc4a76a4d8b88ff4/lib/utils/emitDeprecationWarning.mjs#L3-L11
+const STYLELINT_DEPRECATION_WARNING_PREFIX = 'stylelint:';
+
+type Warning = Error & {
+  code: string;
+};
+
+/**
+ * Quiet all stylelint related deprecation warnings like `context.fix` or `utils.report` API.
+ */
+export default function unsafeQuietStylelintDeprecationWarning(): void {
+  const original = process.emitWarning;
+  process.emitWarning = function emitWarning(...args) {
+    const [message, options] = args;
+
+    if (
+      message &&
+      typeof message === 'string' &&
+      message?.includes(ruleName) &&
+      options &&
+      typeof options === 'object' &&
+      options?.type === 'DeprecationWarning' &&
+      options?.code?.startsWith(STYLELINT_DEPRECATION_WARNING_PREFIX)
+    ) {
+      return;
+    }
+
+    original.apply(process, args);
+  };
+}

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,8 @@
 {
+  "plugins": ["jest"],
+  "env": {
+    "jest/globals": true
+  },
   "globals": {
     "testRule": "readonly",
     "testCustomAutoFixMessage": "readonly"

--- a/test/unsafe-quiet-stylelint-deprecation-warning.js
+++ b/test/unsafe-quiet-stylelint-deprecation-warning.js
@@ -1,0 +1,49 @@
+import process from 'node:process';
+import unsafeQuietStylelintDeprecationWarning from '../src/unsafe-quiet-stylelint-deprecation-warning';
+import { ruleName } from '../src/defaults';
+
+describe('quietContextFixDeprecationWarning', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('quiets context.fix dewprecation warnings', () => {
+    const emitWarningSpy = jest.spyOn(process, 'emitWarning');
+
+    unsafeQuietStylelintDeprecationWarning();
+
+    process.emitWarning(ruleName, {
+      type: 'DeprecationWarning',
+      code: 'stylelint:005',
+    });
+
+    expect(emitWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it('quiets utils.report dewprecation warnings', () => {
+    const emitWarningSpy = jest.spyOn(process, 'emitWarning');
+
+    unsafeQuietStylelintDeprecationWarning();
+
+    process.emitWarning(ruleName, {
+      type: 'DeprecationWarning',
+      code: 'stylelint:007',
+    });
+
+    expect(emitWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-emits unrelated warnings', () => {
+    const emitWarningSpy = jest.spyOn(process, 'emitWarning');
+
+    unsafeQuietStylelintDeprecationWarning();
+
+    process.emitWarning('foo', {
+      type: 'DeprecationWarning',
+      code: 'bar',
+    });
+
+    expect(emitWarningSpy).toHaveBeenCalled();
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
improves #379 

- [x] test before merging

- [x] Upcoming `report.utils` deprecation will have the same issue - [utils.report()](https://github.com/stylelint/stylelint/pull/8244)