### PR TITLE
fix: exclude dependencies from build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.10.9",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "css-values": "^0.1.0",
+        "shortcss": "^0.1.3"
+      },
       "devDependencies": {
         "@babel/cli": "^7.12.8",
         "@babel/core": "^7.20.12",
@@ -31,7 +35,6 @@
         "babel-register-ts": "^7.0.0",
         "codecov": "^3.8.1",
         "cross-env": "^7.0.3",
-        "css-values": "^0.1.0",
         "doctoc": "^2.0.0",
         "dotenv-cli": "^4.0.0",
         "eslint": "^7.14.0",
@@ -50,7 +53,6 @@
         "pinst": "^2.1.6",
         "prettier": "^2.2.1",
         "semantic-release": "^17.3.0",
-        "shortcss": "^0.1.3",
         "stylelint": "^16.1.0",
         "typedoc": "^0.22.7",
         "typedoc-plugin-markdown": "^3.2.1",
@@ -6113,7 +6115,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -6171,10 +6173,10 @@
       }
     },
     "node_modules/css-shorthand-properties": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
-      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "1.1.3",
@@ -6202,7 +6204,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/css-values/-/css-values-0.1.0.tgz",
       "integrity": "sha512-hQ6JSn4t/70aOCvdlP9zTOsFFUifMSKWz3PX7rz5NZl+uEHCqTFVJJvfP07isErCGEVHYoc8Orja8wLKZRvOeg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "css-color-names": "0.0.4",
         "ends-with": "^0.2.0",
@@ -6757,7 +6759,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
       "integrity": "sha512-lRppY4dK3VkqBdR242sKcAJeYc8Gf/DhoX9AWvWI2RzccmLnqBQfwm2k4oSDv5MPDjUqawCauXhZkyWxkVhRsg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17666,7 +17667,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -19125,7 +19126,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/shortcss/-/shortcss-0.1.3.tgz",
       "integrity": "sha512-MIOoTd99CIGTrAuGiMUx9VZrnrZmWzEHuKbGM/w+ia/w98cezhlN9w4aQOVSxswdoqkUnWrMw3tThOi3sevZAg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "css-shorthand-properties": "^1.0.0"
       }
@@ -25731,8 +25732,7 @@
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-      "integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==",
-      "dev": true
+      "integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q=="
     },
     "css-declaration-sorter": {
       "version": "6.4.1",
@@ -25772,10 +25772,9 @@
       }
     },
     "css-shorthand-properties": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
-      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ=="
     },
     "css-tree": {
       "version": "1.1.3",
@@ -25799,7 +25798,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/css-values/-/css-values-0.1.0.tgz",
       "integrity": "sha512-hQ6JSn4t/70aOCvdlP9zTOsFFUifMSKWz3PX7rz5NZl+uEHCqTFVJJvfP07isErCGEVHYoc8Orja8wLKZRvOeg==",
-      "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
         "ends-with": "^0.2.0",
@@ -26209,8 +26207,7 @@
     "ends-with": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
-      "integrity": "sha512-lRppY4dK3VkqBdR242sKcAJeYc8Gf/DhoX9AWvWI2RzccmLnqBQfwm2k4oSDv5MPDjUqawCauXhZkyWxkVhRsg==",
-      "dev": true
+      "integrity": "sha512-lRppY4dK3VkqBdR242sKcAJeYc8Gf/DhoX9AWvWI2RzccmLnqBQfwm2k4oSDv5MPDjUqawCauXhZkyWxkVhRsg=="
     },
     "enquirer": {
       "version": "2.3.6",
@@ -34256,8 +34253,7 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -35357,7 +35353,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/shortcss/-/shortcss-0.1.3.tgz",
       "integrity": "sha512-MIOoTd99CIGTrAuGiMUx9VZrnrZmWzEHuKbGM/w+ia/w98cezhlN9w4aQOVSxswdoqkUnWrMw3tThOi3sevZAg==",
-      "dev": true,
       "requires": {
         "css-shorthand-properties": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "babel-register-ts": "^7.0.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",
-    "css-values": "^0.1.0",
     "doctoc": "^2.0.0",
     "dotenv-cli": "^4.0.0",
     "eslint": "^7.14.0",
@@ -96,7 +95,6 @@
     "pinst": "^2.1.6",
     "prettier": "^2.2.1",
     "semantic-release": "^17.3.0",
-    "shortcss": "^0.1.3",
     "stylelint": "^16.1.0",
     "typedoc": "^0.22.7",
     "typedoc-plugin-markdown": "^3.2.1",
@@ -104,5 +102,9 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "css-values": "^0.1.0",
+    "shortcss": "^0.1.3"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 import type { Declaration, Root, AtRule } from 'postcss';
 import stylelint, { PostcssResult, Rule, RuleMeta } from 'stylelint';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import shortCSS from 'shortcss';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import list from 'shortcss/lib/list';
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/extensions
+import list from 'shortcss/lib/list.js';
 import cssValues from 'css-values';
 
 import {

--- a/types/shortcss.d.ts
+++ b/types/shortcss.d.ts
@@ -1,3 +1,3 @@
 declare module 'shortcss';
 
-declare module 'shortcss/lib/list';
+declare module 'shortcss/lib/list.js';


### PR DESCRIPTION
fix #382 by undoing the in-lining of `shortcss` and `css-values` by #330